### PR TITLE
Enhance UI controls and statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,33 @@
     border: 1px solid blue;
     background: white;
   }
+  #layout {
+    display: flex;
+    align-items: flex-start;
+  }
   #controls {
     margin-top: 10px;
+  }
+  #stats {
+    margin-left: 10px;
+    font-family: sans-serif;
   }
 </style>
 </head>
 <body>
-<canvas id="canvas" width="256" height="256"></canvas>
+<div id="layout">
+  <canvas id="canvas" width="256" height="256"></canvas>
+  <div id="stats">
+    <div>Durchschnittlicher Score: <span id="avgScore">0</span></div>
+    <div>High: <span id="highCount">0</span></div>
+    <div>Low: <span id="lowCount">0</span></div>
+  </div>
+</div>
 <div id="controls">
-  <label>Würmchen: <input type="range" id="wormCount" min="100" max="5000" value="3000"></label>
-  <label>Mutationsrate: <input type="range" id="mutationRate" min="0" max="0.01" step="0.0001" value="0.001"></label>
-  <label>Transferanteil: <input type="range" id="transferFraction" min="0" max="0.2" step="0.01" value="0.1"></label>
+  <label>Würmchen: <input type="range" id="wormCount" min="100" max="5000" value="3000"><span id="wormCountVal"></span></label>
+  <label>Mutationsrate: <input type="range" id="mutationRate" min="0" max="0.01" step="0.0001" value="0.001"><span id="mutationRateVal"></span></label>
+  <label>Transferanteil: <input type="range" id="transferFraction" min="0" max="1" step="0.01" value="0.1"><span id="transferFractionVal"></span></label>
+  <label>Geschwindigkeit: <input type="range" id="simSpeed" min="1" max="5" step="1" value="1"><span id="simSpeedVal"></span></label>
   <button id="restart">Neu starten</button>
 </div>
 <script>
@@ -26,6 +42,20 @@
   const canvas = document.getElementById('canvas');
   const ctx = canvas.getContext('2d');
   const SIZE = 256;
+
+  const valueElems = {
+    wormCount: document.getElementById('wormCountVal'),
+    mutationRate: document.getElementById('mutationRateVal'),
+    transferFraction: document.getElementById('transferFractionVal'),
+    simSpeed: document.getElementById('simSpeedVal')
+  };
+  ['wormCount','mutationRate','transferFraction','simSpeed'].forEach(id=>{
+    const input=document.getElementById(id);
+    const span=valueElems[id];
+    function update(){span.textContent=input.value;}
+    input.addEventListener('input',update);
+    update();
+  });
   const DIRS = [
     [1,0],
     [0,1],
@@ -42,12 +72,13 @@
     const count = parseInt(document.getElementById('wormCount').value,10);
     const mutation = parseFloat(document.getElementById('mutationRate').value);
     const transfer = parseFloat(document.getElementById('transferFraction').value);
+    const speed = parseInt(document.getElementById('simSpeed').value,10);
     worms = [];
     for(let i=0;i<count;i++){
       worms.push(createWorm(i));
     }
     tailMap = new Map();
-    window.simParams = {mutation,transfer};
+    window.simParams = {mutation,transfer,speed};
   }
   function createWorm(index){
     const w={};
@@ -163,7 +194,18 @@
       }
     }
   }
-  function step(){
+  function updateStats(){
+    let high=0,low=0,total=0;
+    for(const w of worms){
+      total+=w.score;
+      if(w.score>0.9) high++;
+      if(w.score<0.1) low++;
+    }
+    document.getElementById('avgScore').textContent=(total/worms.length).toFixed(3);
+    document.getElementById('highCount').textContent=high;
+    document.getElementById('lowCount').textContent=low;
+  }
+  function stepOnce(){
     tailMap=new Map();
     headMap=new Map();
     worms.forEach((w,i)=>{
@@ -180,17 +222,11 @@
     }
     draw();
     stepCounter++;
-    if(stepCounter===10){
-      let high=0,low=0,total=0;
-      for(const w of worms){
-        total+=w.score;
-        if(w.score>0.9) high++;
-        if(w.score<0.1) low++;
-      }
-      console.log('Stats after 10 steps:',
-        'avgScore', (total/worms.length).toFixed(3),
-        'high', high,
-        'low', low);
+    updateStats();
+  }
+  function step(){
+    for(let i=0;i<window.simParams.speed;i++){
+      stepOnce();
     }
     requestAnimationFrame(step);
   }


### PR DESCRIPTION
## Summary
- display simulation statistics next to the canvas
- show current values beside sliders
- add speed slider and allow transfer rate up to 1
- update script to update statistics continuously and respect speed setting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684037006e9c8326b0fbd6a0d5090900