### PR TITLE
Add worm debugger view

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,10 @@
 </head>
 <body>
 <div id="layout">
-  <canvas id="canvas" width="256" height="256"></canvas>
+  <div>
+    <canvas id="canvas" width="256" height="256"></canvas>
+    <canvas id="debugCanvas" width="256" height="256" style="display:none;margin-top:5px;"></canvas>
+  </div>
   <div id="stats">
     <div>Durchschnittlicher Score: <span id="avgScore">0</span></div>
     <div>High: <span id="highCount">0</span></div>
@@ -41,11 +44,14 @@
   <label>Geschwindigkeit: <input type="range" id="simSpeed" min="1" max="5" step="1" value="1"><span id="simSpeedVal"></span></label>
   <button id="restart">Neu starten</button>
 </div>
+<script src="worm_debug.js"></script>
 <script>
 (function(){
   const canvas = document.getElementById('canvas');
   const ctx = canvas.getContext('2d');
+  const debugCanvas = document.getElementById('debugCanvas');
   const SIZE = 256;
+  if(window.wormDebug) wormDebug.init(debugCanvas);
 
   const valueElems = {
     wormCount: document.getElementById('wormCountVal'),
@@ -263,6 +269,17 @@
     requestAnimationFrame(step);
   }
   document.getElementById('restart').addEventListener('click',reset);
+  canvas.addEventListener('click',e=>{
+    const rect=canvas.getBoundingClientRect();
+    const x=Math.floor(e.clientX-rect.left);
+    const y=Math.floor(e.clientY-rect.top);
+    let idx=headMap.get(`${x},${y}`);
+    if(idx===undefined) idx=tailMap.get(`${x},${y}`);
+    if(idx!==undefined){
+      document.getElementById('debugCanvas').style.display='block';
+      wormDebug.show(worms[idx]);
+    }
+  });
   reset();
   requestAnimationFrame(step);
 })();

--- a/worm_debug.js
+++ b/worm_debug.js
@@ -1,0 +1,71 @@
+(function(){
+  const SIZE = 256;
+  let ctx = null;
+
+  function init(canvas){
+    ctx = canvas.getContext('2d');
+    canvas.width = SIZE;
+    canvas.height = SIZE;
+  }
+
+  function drawArrow(fromX, fromY, toX, toY){
+    ctx.beginPath();
+    ctx.moveTo(fromX, fromY);
+    ctx.lineTo(toX, toY);
+    const angle = Math.atan2(toY - fromY, toX - fromX);
+    const arrowLength = 5;
+    ctx.lineTo(toX - arrowLength * Math.cos(angle - Math.PI / 6),
+               toY - arrowLength * Math.sin(angle - Math.PI / 6));
+    ctx.moveTo(toX, toY);
+    ctx.lineTo(toX - arrowLength * Math.cos(angle + Math.PI / 6),
+               toY - arrowLength * Math.sin(angle + Math.PI / 6));
+    ctx.stroke();
+  }
+
+  function show(worm){
+    if(!ctx) return;
+    ctx.clearRect(0, 0, SIZE, SIZE);
+    ctx.font = '10px monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+
+    const cellSize = 28;
+    const offset = 4;
+    // draw data field on upper half
+    for(let i=0;i<32;i++){
+      const col = i % 8;
+      const row = Math.floor(i / 8);
+      const x = offset + col * cellSize;
+      const y = offset + row * cellSize;
+      ctx.fillStyle = '#fff';
+      ctx.strokeStyle = '#000';
+      ctx.fillRect(x,y,cellSize,cellSize);
+      ctx.strokeRect(x,y,cellSize,cellSize);
+      ctx.fillStyle = '#000';
+      ctx.fillText(worm.data[i].toFixed(2), x + cellSize/2, y + 2);
+      // draw index arrow below cell
+      const idxY = y + cellSize + 8;
+      ctx.fillText(i, x + cellSize/2, idxY + 2);
+      drawArrow(x + cellSize/2, idxY, x + cellSize/2, y + cellSize);
+    }
+
+    const progStartY = offset + 4 * cellSize + 20;
+    ctx.textBaseline = 'top';
+    for(let i=0;i<32;i++){
+      const col = i % 8;
+      const row = Math.floor(i / 8);
+      const x = offset + col * cellSize;
+      const y = progStartY + row * cellSize;
+      const ins = worm.program[i];
+      ctx.fillStyle = '#fff';
+      ctx.strokeStyle = '#000';
+      ctx.fillRect(x,y,cellSize,cellSize);
+      ctx.strokeRect(x,y,cellSize,cellSize);
+      ctx.fillStyle = '#000';
+      ctx.fillText(i, x + cellSize/2, y + 2);
+      ctx.fillText(`d${ins.dst}`, x + cellSize/2, y + 12);
+    }
+  }
+
+  window.wormDebug = { init, show };
+})();


### PR DESCRIPTION
## Summary
- add a second canvas to inspect worms
- load new `worm_debug.js` helper
- handle canvas clicks to show clicked worm memory

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684094acf6ec8326b31057f61abe573f